### PR TITLE
Organize stories by features and components

### DIFF
--- a/src/features/group/page.stories.tsx
+++ b/src/features/group/page.stories.tsx
@@ -105,7 +105,7 @@ const FleetwoodMacGroupStory = () => {
 };
 
 const meta = {
-  title: 'Features / Group',
+  title: 'Complete Forms / Group Management',
   component: GroupPageWrapper,
   parameters: {
     layout: 'fullscreen',

--- a/src/features/person/person.stories.tsx
+++ b/src/features/person/person.stories.tsx
@@ -23,7 +23,7 @@ const GroupFormWrapper = (args: { title: string }) => {
 };
 
 const meta = {
-  title: 'Features / Group / GroupForm',
+  title: 'Form Components / GroupForm',
   component: GroupFormWrapper,
   parameters: {
     layout: 'fullscreen',

--- a/src/stories/select.stories.tsx
+++ b/src/stories/select.stories.tsx
@@ -174,7 +174,7 @@ const SelectStoryComponent = () => {
 };
 
 const meta = {
-  title: 'Components / Select',
+  title: 'Form Components / Select',
   component: SelectStoryComponent,
 } satisfies Meta<typeof SelectStoryComponent>;
 

--- a/src/stories/zod-v4-validation.stories.tsx
+++ b/src/stories/zod-v4-validation.stories.tsx
@@ -447,7 +447,7 @@ const RefineExampleForm = () => {
 };
 
 const meta = {
-  title: 'Examples / Zod v4 Validation',
+  title: 'Validation / Zod v4',
   component: ZodV4ValidationForm,
   parameters: {
     layout: 'fullscreen',


### PR DESCRIPTION
Restructure story organization from confusing "Features", "Components", and "Examples" categories into three clear categories:

- Form Components/ - Individual reusable form field components
- Complete Forms/ - Full working form examples showing composition
- Validation/ - Validation-focused examples and patterns

Changes:
- Features/Group → Complete Forms/Group Management
- Features/Group/GroupForm → Form Components/GroupForm
- Components/Select → Form Components/Select
- Examples/Zod v4 Validation → Validation/Zod v4

This makes it easier for users to find what they need in Storybook.